### PR TITLE
parametrize sleep time and bump it to 600 milliseconds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ const result = await upload({
     apiUploadEndpoint: 'rewriteDefauitDiawiUploadEndpoint',
     apiStatusEndpoint: 'rewriteDefauitDiawiStatusEndpoint',
     maxApiStatusCalls: 99,
+    sleepMilliseconds: 600,
     onUploadProgress: (progressPercent) => {
         console.log(`uploading: ${progressPercent}`);
     },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,7 @@
 export const API_UPLOAD = 'https://upload.diawi.com';
 export const API_STATUS = 'https://upload.diawi.com/status';
 export const DEFAULT_MAX_API_STATUS_CALLS = 30;
+export const DEFAULT_SLEEP_MILLISECONDS = 600;
 
 export enum JOB_STATUS {
     OK = 2000,

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -1,10 +1,11 @@
 import { ApiStatusResponse, ApiUploadProps, StatusOptions, UploadOptions } from '@app/types';
 import { rawUpload, fetchJobStatus } from '@app/core';
-import { JOB_STATUS, DEFAULT_MAX_API_STATUS_CALLS, API_UPLOAD, API_STATUS } from '@app/constants';
+import { JOB_STATUS, DEFAULT_MAX_API_STATUS_CALLS, DEFAULT_PROCEEDING_SLEEP_TIME, API_UPLOAD, API_STATUS } from '@app/constants';
 import { noop, sleep } from '@app/utils';
 
 interface Options extends UploadOptions, StatusOptions {
     maxApiStatusCalls?: number;
+    sleepMilliseconds?: number;
     onStatusProgress?: (status: JOB_STATUS) => any;
 }
 
@@ -15,6 +16,7 @@ export const upload = async (props: ApiUploadProps, options: Options = {}) => {
     // default params
     const {
         maxApiStatusCalls = DEFAULT_MAX_API_STATUS_CALLS,
+        sleepMilliseconds = DEFAULT_SLEEP_MILLISECONDS,
         onUploadProgress = noop,
         onStatusProgress = noop,
         apiUploadEndpoint = API_UPLOAD,
@@ -43,7 +45,7 @@ export const upload = async (props: ApiUploadProps, options: Options = {}) => {
                 throw new Error(message);
             }
             case JOB_STATUS.PROCEEDING: {
-                await sleep(300);
+                await sleep(sleepMilliseconds);
                 return checkStatus();
             }
             default: {


### PR DESCRIPTION
The current value is too low and causes failures like this:
```
{ error: 4000000, message: 'Too many requests' }
```
According to Diawi support limit of status checks is two per second:

>Your guess is correct, there is a limit on the number of requests for the status check of an upload (2 requests every second)... and it seems that the library your are using is making requests too fast. Could you try using 600ms instead of 300ms?